### PR TITLE
feat: add asvec formula, templates, and workflows vec-579

### DIFF
--- a/.github/workflows/asvec-auto.yml
+++ b/.github/workflows/asvec-auto.yml
@@ -20,10 +20,10 @@ jobs:
               run: |
                 mkdir /tmp/binaries
                 pushd /tmp/binaries
-                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-linux-amd64-${version}.zip
-                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-linux-arm64-${version}.zip
-                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-macos-amd64-${version}.zip
-                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-macos-arm64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/v${version}/asvec-linux-amd64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/v${version}/asvec-linux-arm64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/v${version}/asvec-macos-amd64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/v${version}/asvec-macos-arm64-${version}.zip
                 popd
             - name: Create new local branch
               run: |

--- a/.github/workflows/asvec-auto.yml
+++ b/.github/workflows/asvec-auto.yml
@@ -1,0 +1,66 @@
+name: Asvec - new version - auto trigger
+
+on:
+  repository_dispatch:
+    types: asvec
+
+jobs:
+    release:
+      runs-on: macos-13
+      steps:
+            - name: "Git checkout"
+              uses: actions/checkout@v3
+            - name: Configure Git
+              run: |
+                git config --global user.name "github-actions[bot]"
+                git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            - name: "Get files from asvec"
+              env:
+                  version: ${{ github.event.client_payload.version }}
+              run: |
+                mkdir /tmp/binaries
+                pushd /tmp/binaries
+                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-linux-amd64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-linux-arm64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-macos-amd64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-macos-arm64-${version}.zip
+                popd
+            - name: Create new local branch
+              run: |
+                git checkout -b asvec
+            - name: "Create rb files"
+              env:
+                  version: ${{ github.event.client_payload.version }}
+                  isLatest: ${{ github.event.client_payload.isLatest }}
+              run: |
+                cp templates/asvec/asvec-template Formula/asvec/asvec@${version}.rb
+                cd Formula/asvec
+                sed -i.bak "s/AVERSION/${version}/g" asvec@${version}.rb
+                nsum=$(shasum -a 256 /tmp/binaries/asvec-macos-amd64-${version}.zip| awk '{print $1}')
+                sed -i.bak "s/MACOSAMD/${nsum}/g" asvec@${version}.rb
+                nsum=$(shasum -a 256 /tmp/binaries/asvec-macos-arm64-${version}.zip| awk '{print $1}')
+                sed -i.bak "s/MACOSARM/${nsum}/g" asvec@${version}.rb
+                nsum=$(shasum -a 256 /tmp/binaries/asvec-linux-amd64-${version}.zip| awk '{print $1}')
+                sed -i.bak "s/LINUXAMD/${nsum}/g" asvec@${version}.rb
+                nsum=$(shasum -a 256 /tmp/binaries/asvec-linux-arm64-${version}.zip| awk '{print $1}')
+                sed -i.bak "s/LINUXARM/${nsum}/g" asvec@${version}.rb
+                if [ "${isLatest}" = "true" ]
+                then
+                  cp asvec@${version}.rb asvec.rb
+                  sed -i.bak 's/ACLASS/Asvec/g' asvec.rb
+                fi
+                vernodot=${version//./}
+                sed -i.bak "s/ACLASS/AsvecAT${vernodot}/g" asvec@${version}.rb
+                cd ../..
+            - name: Commit and Push changes
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                version: ${{ github.event.client_payload.version }}
+                isLatest: ${{ github.event.client_payload.isLatest }}
+              run: |
+                git add Formula/asvec/asvec@${version}.rb
+                [ "${isLatest}" = "true" ] && git add Formula/asvec/asvec.rb
+                git commit -m "Release asvec ${version}"
+                git push -u origin asvec
+                gh pr create -f
+                gh pr merge --admin -d $(gh pr list --json number,headRefName -s open |jq '.[] | select(.headRefName == "asvec") | .number') -m

--- a/.github/workflows/asvec.yml
+++ b/.github/workflows/asvec.yml
@@ -8,7 +8,7 @@ on:
                 required: false
                 type: boolean
             version:
-                description: "Version (ex: 7.6.3)"
+                description: "Version (ex: 7.6.3, not v7.6.3)"
                 required: true
 
 jobs:

--- a/.github/workflows/asvec.yml
+++ b/.github/workflows/asvec.yml
@@ -1,0 +1,73 @@
+name: Asvec - new version
+
+on:
+    workflow_dispatch:
+        inputs:
+            isLatest:
+                description: 'Is Latest?'
+                required: false
+                type: boolean
+            version:
+                description: "Version (ex: 7.6.3)"
+                required: true
+
+jobs:
+    release:
+      runs-on: macos-13
+      steps:
+            - name: "Git checkout"
+              uses: actions/checkout@v3
+            - name: Configure Git
+              run: |
+                git config --global user.name "github-actions[bot]"
+                git config --global user.email "github-actions[bot]@users.noreply.github.com"
+            - name: "Get files from asvec"
+              env:
+                  version: ${{ inputs.version }}
+              run: |
+                mkdir /tmp/binaries
+                pushd /tmp/binaries
+                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-linux-amd64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-linux-arm64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-macos-amd64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-macos-arm64-${version}.zip
+                popd
+            - name: Create new local branch
+              run: |
+                git checkout -b asvec
+            - name: "Create rb files"
+              env:
+                  version: ${{ inputs.version }}
+                  isLatest: ${{ inputs.isLatest }}
+              run: |
+                cp templates/asvec/asvec-template Formula/asvec/asvec@${version}.rb
+                cd Formula/asvec
+                sed -i.bak "s/AVERSION/${version}/g" asvec@${version}.rb
+                nsum=$(shasum -a 256 /tmp/binaries/asvec-macos-amd64-${version}.zip| awk '{print $1}')
+                sed -i.bak "s/MACOSAMD/${nsum}/g" asvec@${version}.rb
+                nsum=$(shasum -a 256 /tmp/binaries/asvec-macos-arm64-${version}.zip| awk '{print $1}')
+                sed -i.bak "s/MACOSARM/${nsum}/g" asvec@${version}.rb
+                nsum=$(shasum -a 256 /tmp/binaries/asvec-linux-amd64-${version}.zip| awk '{print $1}')
+                sed -i.bak "s/LINUXAMD/${nsum}/g" asvec@${version}.rb
+                nsum=$(shasum -a 256 /tmp/binaries/asvec-linux-arm64-${version}.zip| awk '{print $1}')
+                sed -i.bak "s/LINUXARM/${nsum}/g" asvec@${version}.rb
+                if [ "${isLatest}" = "true" ]
+                then
+                  cp asvec@${version}.rb asvec.rb
+                  sed -i.bak 's/ACLASS/Asvec/g' asvec.rb
+                fi
+                vernodot=${version//./}
+                sed -i.bak "s/ACLASS/AsvecAT${vernodot}/g" asvec@${version}.rb
+                cd ../..
+            - name: Commit and Push changes
+              env:
+                GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                version: ${{ inputs.version }}
+                isLatest: ${{ inputs.isLatest }}
+              run: |
+                git add Formula/asvec/asvec@${version}.rb
+                [ "${isLatest}" = "true" ] && git add Formula/asvec/asvec.rb
+                git commit -m "Release asvec ${version}"
+                git push -u origin asvec
+                gh pr create -f
+                gh pr merge --admin -d $(gh pr list --json number,headRefName -s open |jq '.[] | select(.headRefName == "asvec") | .number') -m

--- a/.github/workflows/asvec.yml
+++ b/.github/workflows/asvec.yml
@@ -27,10 +27,10 @@ jobs:
               run: |
                 mkdir /tmp/binaries
                 pushd /tmp/binaries
-                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-linux-amd64-${version}.zip
-                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-linux-arm64-${version}.zip
-                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-macos-amd64-${version}.zip
-                wget -q https://github.com/aerospike/asvec/releases/download/${version}/asvec-macos-arm64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/v${version}/asvec-linux-amd64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/v${version}/asvec-linux-arm64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/v${version}/asvec-macos-amd64-${version}.zip
+                wget -q https://github.com/aerospike/asvec/releases/download/v${version}/asvec-macos-arm64-${version}.zip
                 popd
             - name: Create new local branch
               run: |

--- a/Formula/asvec/asvec.rb
+++ b/Formula/asvec/asvec.rb
@@ -1,6 +1,6 @@
 class Asvec < Formula
   desc ""
-  homepage "https://github.com/dwelch-spike/homebrew-tools"
+  homepage "https://github.com/aerospike/homebrew-tools"
   version "3.2.0"
 
   on_macos do

--- a/Formula/asvec/asvec@3.2.0.rb
+++ b/Formula/asvec/asvec@3.2.0.rb
@@ -1,6 +1,6 @@
 class AsvecAT320 < Formula
   desc ""
-  homepage "https://github.com/dwelch-spike/homebrew-tools"
+  homepage "https://github.com/aerospike/homebrew-tools"
   version "3.2.0"
 
   on_macos do

--- a/Formula/asvec/asvec@3.2.0.rb
+++ b/Formula/asvec/asvec@3.2.0.rb
@@ -1,4 +1,4 @@
-class Asvec < Formula
+class AsvecAT320 < Formula
   desc ""
   homepage "https://github.com/dwelch-spike/homebrew-tools"
   version "3.2.0"

--- a/README.md
+++ b/README.md
@@ -5,3 +5,4 @@
 Name | Description | Project URL
 --- | --- | ---
 [Aerolab](aerolab.md) | AeroLab install formula for linux and macos | [https://github.com/aerospike/aerolab](https://github.com/aerospike/aerolab)
+[Asvec](asvec.md) | Asvec install formula for linux and macos | [https://github.com/aerospike/asvec](https://github.com/aerospike/asvec)

--- a/asvec.md
+++ b/asvec.md
@@ -1,0 +1,73 @@
+# Asvec Homebrew Tap
+
+## Install
+
+Install with `brew install aerospike/tools/asvec`
+
+Example output:
+
+```
+% brew install aerospike/tools/asvec             
+==> Tapping aerospike/tools
+Cloning into '/usr/local/Homebrew/Library/Taps/aerospike/homebrew-tools'...
+remote: Enumerating objects: 6, done.
+remote: Counting objects: 100% (6/6), done.
+remote: Compressing objects: 100% (4/4), done.
+remote: Total 6 (delta 1), reused 0 (delta 0), pack-reused 0 (from 0)
+Receiving objects: 100% (6/6), done.
+Resolving deltas: 100% (1/1), done.
+Tapped 1 formula (12 files, 7.6KB).
+==> Fetching aerospike/tools/asvec
+==> Downloading https://github.com/aerospike/asvec/releases/download/v3.2.0/asvec-macos-amd64-3.2.0.zip
+==> Downloading from https://objects.githubusercontent.com/github-production-release-asset-2e65be/...
+##################################################################################################################################################################################################################### 100.0%
+==> Installing asvec from aerospike/tools
+🍺  /usr/local/Cellar/asvec/3.2.0: 4 files, 14.4MB, built in 2 seconds
+==> Running `brew cleanup asvec`...
+Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
+Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
+```
+
+## Check
+
+Open a new terminal window and run:
+
+```
+% asvec version
+```
+
+## Upgrading
+
+`brew upgrade aerospike/tools/asvec`
+
+## Downgrading / Upgrading to specific versions
+
+Install latest version:
+
+```
+% brew update
+
+% brew install aerospike/tools/asvec
+
+% brew unlink asvec && brew link --overwrite asvec
+```
+
+Install older version:
+
+```
+% brew update
+
+% brew install aerospike/tools/asvec@1.0.0
+
+% brew unlink asvec@1.0.0 && brew link --overwrite asvec@1.0.0
+```
+
+Install newer version:
+
+```
+% brew update
+
+% brew install aerospike/tools/asvec@2.0.0
+
+% brew unlink asvec@2.0.0 && brew link --overwrite asvec@2.0.0
+``` 

--- a/templates/asvec/asvec-template
+++ b/templates/asvec/asvec-template
@@ -1,6 +1,6 @@
 class ACLASS < Formula
   desc ""
-  homepage "https://github.com/dwelch-spike/homebrew-tools"
+  homepage "https://github.com/aerospike/homebrew-tools"
   version "AVERSION"
 
   on_macos do

--- a/templates/asvec/asvec-template
+++ b/templates/asvec/asvec-template
@@ -1,11 +1,11 @@
 class ACLASS < Formula
   desc ""
-  homepage "https://github.com/aerospike/homebrew-tools"
+  homepage "https://github.com/dwelch-spike/homebrew-tools"
   version "AVERSION"
 
   on_macos do
     if Hardware::CPU.intel?
-      url "https://github.com/aerospike/asvec/releases/download/AVERSION/asvec-macos-amd64-AVERSION.zip"
+      url "https://github.com/aerospike/asvec/releases/download/vAVERSION/asvec-macos-amd64-AVERSION.zip"
       sha256 "MACOSAMD"
 
       def install
@@ -13,7 +13,7 @@ class ACLASS < Formula
       end
     end
     if Hardware::CPU.arm?
-      url "https://github.com/aerospike/asvec/releases/download/AVERSION/asvec-macos-arm64-AVERSION.zip"
+      url "https://github.com/aerospike/asvec/releases/download/vAVERSION/asvec-macos-arm64-AVERSION.zip"
       sha256 "MACOSARM"
 
       def install
@@ -24,7 +24,7 @@ class ACLASS < Formula
 
   on_linux do
     if Hardware::CPU.intel?
-      url "https://github.com/aerospike/asvec/releases/download/AVERSION/asvec-linux-amd64-AVERSION.zip"
+      url "https://github.com/aerospike/asvec/releases/download/vAVERSION/asvec-linux-amd64-AVERSION.zip"
       sha256 "LINUXAMD"
 
       def install
@@ -32,7 +32,7 @@ class ACLASS < Formula
       end
     end
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
-      url "https://github.com/aerospike/asvec/releases/download/AVERSION/asvec-linux-arm64-AVERSION.zip"
+      url "https://github.com/aerospike/asvec/releases/download/vAVERSION/asvec-linux-arm64-AVERSION.zip"
       sha256 "LINUXARM"
 
       def install

--- a/templates/asvec/asvec-template
+++ b/templates/asvec/asvec-template
@@ -1,0 +1,43 @@
+class ACLASS < Formula
+  desc ""
+  homepage "https://github.com/aerospike/homebrew-tools"
+  version "AVERSION"
+
+  on_macos do
+    if Hardware::CPU.intel?
+      url "https://github.com/aerospike/asvec/releases/download/AVERSION/asvec-macos-amd64-AVERSION.zip"
+      sha256 "MACOSAMD"
+
+      def install
+        bin.install "asvec"
+      end
+    end
+    if Hardware::CPU.arm?
+      url "https://github.com/aerospike/asvec/releases/download/AVERSION/asvec-macos-arm64-AVERSION.zip"
+      sha256 "MACOSARM"
+
+      def install
+        bin.install "asvec"
+      end
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.intel?
+      url "https://github.com/aerospike/asvec/releases/download/AVERSION/asvec-linux-amd64-AVERSION.zip"
+      sha256 "LINUXAMD"
+
+      def install
+        bin.install "asvec"
+      end
+    end
+    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
+      url "https://github.com/aerospike/asvec/releases/download/AVERSION/asvec-linux-arm64-AVERSION.zip"
+      sha256 "LINUXARM"
+
+      def install
+        bin.install "asvec"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is pretty much a copy of the aerolab workflows. I tested this in my own fork and was able to install it using
```
brew install dwelch-spike/tools/asvec
```

I also tested the manual action in my fork, it generated the new ruby files (besides the template) in this PR.